### PR TITLE
chore: add PORT to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,6 @@ EMAIL_SMTP_USERNAME=YourSMTPUsername
 EMAIL_SMTP_PASSWORD=YourSMTPPassword
 # true for 465, false for other ports
 EMAIL_SMTP_SECURE=false
+
+PORT=your_port
+# Example 4000, 3000, 9348

--- a/bin/www
+++ b/bin/www
@@ -4,16 +4,16 @@
  * Module dependencies.
  */
 
-var app = require('../app');
-var debug = require('debug')('rest-api-nodejs-mongodb:server');
-var http = require('http');
+var app = require("../app");
+var debug = require("debug")("rest-api-nodejs-mongodb:server");
+var http = require("http");
 
 /**
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '3000');
-app.set('port', port);
+var port = normalizePort(process.env.PORT || "3000");
+app.set("port", port);
 
 /**
  * Create HTTP server.
@@ -26,8 +26,8 @@ var server = http.createServer(app);
  */
 
 server.listen(port);
-server.on('error', onError);
-server.on('listening', onListening);
+server.on("error", onError);
+server.on("listening", onListening);
 
 /**
  * Normalize a port into a number, string, or false.
@@ -54,22 +54,20 @@ function normalizePort(val) {
  */
 
 function onError(error) {
-  if (error.syscall !== 'listen') {
+  if (error.syscall !== "listen") {
     throw error;
   }
 
-  var bind = typeof port === 'string'
-    ? 'Pipe ' + port
-    : 'Port ' + port;
+  var bind = typeof port === "string" ? "Pipe " + port : "Port " + port;
 
   // handle specific listen errors with friendly messages
   switch (error.code) {
-    case 'EACCES':
-      console.error(bind + ' requires elevated privileges');
+    case "EACCES":
+      console.error(bind + " requires elevated privileges");
       process.exit(1);
       break;
-    case 'EADDRINUSE':
-      console.error(bind + ' is already in use');
+    case "EADDRINUSE":
+      console.error(bind + " is already in use");
       process.exit(1);
       break;
     default:
@@ -83,8 +81,6 @@ function onError(error) {
 
 function onListening() {
   var addr = server.address();
-  var bind = typeof addr === 'string'
-    ? 'pipe ' + addr
-    : 'port ' + addr.port;
-  debug('Listening on ' + bind);
+  var bind = typeof addr === "string" ? "pipe " + addr : "port " + addr.port;
+  debug("Listening on " + bind);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "rest-api-nodejs-mongodb",
+  "name": "team_titan_sms_micro_service_api",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
Add port option to .env.example to facilitate the adding of PORTS